### PR TITLE
without encoding this example not work with cyrillic, but this packag…

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ use Bukashk0zzz\YmlGenerator\Generator;
 $file = tempnam(sys_get_temp_dir(), 'YMLGenerator');
 $settings = (new Settings())
     ->setOutputFile($file)
+    ->setEncoding('UTF-8')
 ;
 
 // Creating ShopInfo object (https://yandex.ru/support/webmaster/goods-prices/technical-requirements.xml#shop)


### PR DESCRIPTION
…e will be used for cyrillic basically. Maybe it needs to set default value UTF-8 for encoding in Settings setEncoding?