### PR TITLE
Добавляет возможность управлять тегами barcode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "php": ">=5.6.1"
     },
     "require-dev": {
+        "ext-dom": "*",
         "phpunit/phpunit": "^5.0",
         "fzaninotto/faker": "^1.6",
         "friendsofphp/php-cs-fixer": "^2.3",

--- a/src/Model/Offer/AbstractOffer.php
+++ b/src/Model/Offer/AbstractOffer.php
@@ -561,6 +561,7 @@ abstract class AbstractOffer implements OfferInterface
      * Set list of barcodes for that offer
      *
      * @param string[] $barcodes
+     *
      * @return $this
      */
     public function setBarcodes(array $barcodes = [])
@@ -573,11 +574,15 @@ abstract class AbstractOffer implements OfferInterface
     /**
      * Add one barcode to the collection of barcodes of this offer
      *
-     * @param $barcode
+     * @param string $barcode
+     *
+     * @return AbstractOffer
      */
     public function addBarcode($barcode)
     {
         $this->barcodes[] = $barcode;
+
+        return $this;
     }
 
     /**

--- a/src/Model/Offer/AbstractOffer.php
+++ b/src/Model/Offer/AbstractOffer.php
@@ -106,6 +106,9 @@ abstract class AbstractOffer implements OfferInterface
      */
     private $cpa;
 
+    /** @var string[] */
+    private $barcodes;
+
     /**
      * @var array
      */
@@ -545,6 +548,39 @@ abstract class AbstractOffer implements OfferInterface
     }
 
     /**
+     * Get list of barcodes of the offer
+     *
+     * @return string[]
+     */
+    public function getBarcodes()
+    {
+        return $this->barcodes;
+    }
+
+    /**
+     * Set list of barcodes for that offer
+     *
+     * @param string[] $barcodes
+     * @return $this
+     */
+    public function setBarcodes(array $barcodes = [])
+    {
+        $this->barcodes = $barcodes;
+
+        return $this;
+    }
+
+    /**
+     * Add one barcode to the collection of barcodes of this offer
+     *
+     * @param $barcode
+     */
+    public function addBarcode($barcode)
+    {
+        $this->barcodes[] = $barcode;
+    }
+
+    /**
      * @return array
      */
     abstract protected function getOptions();
@@ -581,6 +617,7 @@ abstract class AbstractOffer implements OfferInterface
             'downloadable' => $this->isDownloadable(),
             'adult' => $this->isAdult(),
             'cpa' => $this->getCpa(),
+            'barcode' => $this->getBarcodes(),
         ];
     }
 }

--- a/tests/AbstractGeneratorTest.php
+++ b/tests/AbstractGeneratorTest.php
@@ -227,6 +227,7 @@ abstract class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
                 ->setAdult($this->faker->boolean)
                 ->setMarketCategory($this->faker->word)
                 ->setCpa($this->faker->numberBetween(0, 1))
+                ->setBarcodes([$this->faker->ean13, $this->faker->ean13])
             ;
         }
 

--- a/tests/OfferSimpleGeneratorTest.php
+++ b/tests/OfferSimpleGeneratorTest.php
@@ -39,6 +39,7 @@ class OfferSimpleGeneratorTest extends AbstractGeneratorTest
             ->setPickup(true)
             ->setGroupId($this->faker->numberBetween())
             ->addPicture('http://example.com/example.jpeg')
+            ->addBarcode($this->faker->ean13)
         ;
     }
 }


### PR DESCRIPTION
Добавлено поле `barcodes` для `\Bukashk0zzz\YmlGenerator\Model\Offer\AbstractOffer`, а также сопутствующие методы для него.

Попутно добавил в require-dev зависимость от ext-dom, т.к. без него проверка dtd работать не будет. PhpStorm все равно ругается, просит добавить в require секцию, но я не стал. 

Добавил также в `\Bukashk0zzz\YmlGenerator\Tests\AbstractGeneratorTest::createOffers` новое поле, генерируется с помощью Faker'а