### PR TITLE
Added Cdata class to allow writing of CDATA values

### DIFF
--- a/src/Cdata.php
+++ b/src/Cdata.php
@@ -1,12 +1,20 @@
 <?php
 
+/*
+ * This file is part of the Bukashk0zzzYmlGenerator
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Bukashk0zzz\YmlGenerator;
 
 /**
  * Represents a value that should be written to XML as CDATA
  * @author zyura (https://github.com/zyura)
  */
-class Cdata {
+class Cdata
+{
     /**
      * @var string
      */
@@ -20,6 +28,11 @@ class Cdata {
         $this->value = $value;
     }
 
+    /**
+     * Allows to get the wrapped value by casting an instance to string
+     *
+     * @return string
+     */
     public function __toString()
     {
         return $this->value;

--- a/src/Cdata.php
+++ b/src/Cdata.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Bukashk0zzz\YmlGenerator;
+
+/**
+ * Represents a value that should be written to XML as CDATA
+ * @author zyura (https://github.com/zyura)
+ */
+class Cdata {
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    public function __toString()
+    {
+        return $this->value;
+    }
+}

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -313,10 +313,11 @@ class Generator
         }
 
         if ($value instanceof Cdata) {
-        	$this->writer->startElement($name);
-        	$this->writer->writeCdata((string) $value);
-        	$this->writer->endElement();
-        	return true;
+            $this->writer->startElement($name);
+            $this->writer->writeCdata((string) $value);
+            $this->writer->endElement();
+
+            return true;
         }
 
         if (\is_bool($value)) {

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -312,6 +312,13 @@ class Generator
             return false;
         }
 
+        if ($value instanceof Cdata) {
+        	$this->writer->startElement($name);
+        	$this->writer->writeCdata((string) $value);
+        	$this->writer->endElement();
+        	return true;
+        }
+
         if (\is_bool($value)) {
             $value = $value ? 'true' : 'false';
         }

--- a/tests/AbstractGeneratorTest.php
+++ b/tests/AbstractGeneratorTest.php
@@ -95,6 +95,40 @@ abstract class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @return array
+     */
+    protected function createOffers()
+    {
+        $offers = [];
+        foreach (\range(1, 2) as $id) {
+            $offers[] = $this
+                ->createOffer()
+                ->setId($id)
+                ->setAvailable($this->faker->boolean)
+                ->setUrl($this->faker->url)
+                ->setPrice($this->faker->numberBetween(1, 9999))
+                ->setOldPrice($this->faker->numberBetween(1, 9999))
+                ->setWeight($this->faker->numberBetween(1, 9999))
+                ->setCurrencyId('UAH')
+                ->setCategoryId($id)
+                ->setDelivery($this->faker->boolean)
+                ->setLocalDeliveryCost($this->faker->numberBetween(1, 9999))
+                ->setDescription($this->faker->sentence)
+                ->setSalesNotes($this->faker->text(45))
+                ->setManufacturerWarranty($this->faker->boolean)
+                ->setCountryOfOrigin('Украина')
+                ->setDownloadable($this->faker->boolean)
+                ->setAdult($this->faker->boolean)
+                ->setMarketCategory($this->faker->word)
+                ->setCpa($this->faker->numberBetween(0, 1))
+                ->setBarcodes([$this->faker->ean13, $this->faker->ean13])
+            ;
+        }
+
+        return $offers;
+    }
+
+    /**
      * Validate yml file using dtd
      */
     private function validateFileWithDtd()
@@ -199,39 +233,5 @@ abstract class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
             ->setOrderBefore(14);
 
         return $deliveries;
-    }
-
-    /**
-     * @return array
-     */
-    protected function createOffers()
-    {
-        $offers = [];
-        foreach (\range(1, 2) as $id) {
-            $offers[] = $this
-                ->createOffer()
-                ->setId($id)
-                ->setAvailable($this->faker->boolean)
-                ->setUrl($this->faker->url)
-                ->setPrice($this->faker->numberBetween(1, 9999))
-                ->setOldPrice($this->faker->numberBetween(1, 9999))
-                ->setWeight($this->faker->numberBetween(1, 9999))
-                ->setCurrencyId('UAH')
-                ->setCategoryId($id)
-                ->setDelivery($this->faker->boolean)
-                ->setLocalDeliveryCost($this->faker->numberBetween(1, 9999))
-                ->setDescription($this->faker->sentence)
-                ->setSalesNotes($this->faker->text(45))
-                ->setManufacturerWarranty($this->faker->boolean)
-                ->setCountryOfOrigin('Украина')
-                ->setDownloadable($this->faker->boolean)
-                ->setAdult($this->faker->boolean)
-                ->setMarketCategory($this->faker->word)
-                ->setCpa($this->faker->numberBetween(0, 1))
-                ->setBarcodes([$this->faker->ean13, $this->faker->ean13])
-            ;
-        }
-
-        return $offers;
     }
 }

--- a/tests/AbstractGeneratorTest.php
+++ b/tests/AbstractGeneratorTest.php
@@ -204,7 +204,7 @@ abstract class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
     /**
      * @return array
      */
-    private function createOffers()
+    protected function createOffers()
     {
         $offers = [];
         foreach (\range(1, 2) as $id) {

--- a/tests/OfferCdataGeneratorTest.php
+++ b/tests/OfferCdataGeneratorTest.php
@@ -21,6 +21,16 @@ class OfferCdataGeneratorTest extends AbstractGeneratorTest
     const OFFER_COUNT = 2;
 
     /**
+     * Test generate
+     */
+    public function testGenerate()
+    {
+        $this->offerType = 'Simple';
+        $this->runGeneratorTest();
+        $this->checkCdata();
+    }
+
+    /**
      * Need to override parent::createOffers() in order to avoid setting description
      * after calling self::createOffer()
      *
@@ -41,7 +51,14 @@ class OfferCdataGeneratorTest extends AbstractGeneratorTest
         return $offers;
     }
 
-    protected function createOffer() {
+    /**
+     * Set the test description with CDATA here
+     *
+     * {@inheritDoc}
+     * @see \Bukashk0zzz\YmlGenerator\Tests\AbstractGeneratorTest::createOffer()
+     */
+    protected function createOffer()
+    {
         return (new OfferSimple())
             ->setAvailable($this->faker->boolean)
             ->setUrl($this->faker->url)
@@ -71,7 +88,11 @@ class OfferCdataGeneratorTest extends AbstractGeneratorTest
         ;
     }
 
-    private function checkCdata() {
+    /**
+     * Retreive and check CDATA from the generated file
+     */
+    private function checkCdata()
+    {
         $ymlFile = new \DOMDocument();
         $ymlFile->loadXML(\file_get_contents($this->settings->getOutputFile()));
 
@@ -90,17 +111,12 @@ class OfferCdataGeneratorTest extends AbstractGeneratorTest
     }
 
     /**
-     * Test generate
+     * Create instance of Cdata class with a predefined test string
+     *
+     * @return \Bukashk0zzz\YmlGenerator\Cdata
      */
-    public function testGenerate()
+    private function makeDescription()
     {
-        $this->offerType = 'Simple';
-        $this->runGeneratorTest();
-        $this->checkCdata();
-    }
-
-    private function makeDescription() {
         return new Cdata(self::CDATA_TEST_STRING);
     }
-
 }

--- a/tests/OfferCdataGeneratorTest.php
+++ b/tests/OfferCdataGeneratorTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Bukashk0zzzYmlGenerator
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Bukashk0zzz\YmlGenerator\Tests;
+
+use Bukashk0zzz\YmlGenerator\Model\Offer\OfferSimple;
+use Bukashk0zzz\YmlGenerator\Cdata;
+
+/**
+ * Generator test
+ */
+class OfferCdataGeneratorTest extends AbstractGeneratorTest
+{
+    const CDATA_TEST_STRING = '<p>Simple HTML</p></description></offer><![CDATA[';
+    const OFFER_COUNT = 2;
+
+    /**
+     * Need to override parent::createOffers() in order to avoid setting description
+     * after calling self::createOffer()
+     *
+     * {@inheritDoc}
+     * @see \Bukashk0zzz\YmlGenerator\Tests\AbstractGeneratorTest::createOffers()
+     */
+    protected function createOffers()
+    {
+        $offers = [];
+        foreach (\range(1, self::OFFER_COUNT) as $id) {
+            $offers[] =
+                $this->createOffer()
+                    ->setId($id)
+                    ->setCategoryId($id)
+                ;
+        }
+
+        return $offers;
+    }
+
+    protected function createOffer() {
+        return (new OfferSimple())
+            ->setAvailable($this->faker->boolean)
+            ->setUrl($this->faker->url)
+            ->setPrice($this->faker->numberBetween(1, 9999))
+            ->setOldPrice($this->faker->numberBetween(1, 9999))
+            ->setWeight($this->faker->numberBetween(1, 9999))
+            ->setCurrencyId('UAH')
+            ->setDelivery($this->faker->boolean)
+            ->setLocalDeliveryCost($this->faker->numberBetween(1, 9999))
+            ->setSalesNotes($this->faker->text(45))
+            ->setManufacturerWarranty($this->faker->boolean)
+            ->setCountryOfOrigin('Украина')
+            ->setDownloadable($this->faker->boolean)
+            ->setAdult($this->faker->boolean)
+            ->setMarketCategory($this->faker->word)
+            ->setCpa($this->faker->numberBetween(0, 1))
+            ->setBarcodes([$this->faker->ean13, $this->faker->ean13])
+
+            ->setName($this->faker->name)
+            ->setVendor($this->faker->company)
+            ->setDescription($this->makeDescription())
+            ->setVendorCode(null)
+            ->setPickup(true)
+            ->setGroupId($this->faker->numberBetween())
+            ->addPicture('http://example.com/example.jpeg')
+            ->addBarcode($this->faker->ean13)
+        ;
+    }
+
+    private function checkCdata() {
+        $ymlFile = new \DOMDocument();
+        $ymlFile->loadXML(\file_get_contents($this->settings->getOutputFile()));
+
+        $xpath = new \DOMXPath($ymlFile);
+        $descriptionNodes = $xpath->query('//yml_catalog/shop/offers/offer/description');
+        self::assertNotFalse($descriptionNodes);
+
+        // One description per offer is expected
+        self::assertEquals(self::OFFER_COUNT, $descriptionNodes->length);
+
+        foreach ($descriptionNodes as $descriptionNode) {
+            $description = $descriptionNode->nodeValue;
+
+            self::assertSame(self::CDATA_TEST_STRING, $description);
+        }
+    }
+
+    /**
+     * Test generate
+     */
+    public function testGenerate()
+    {
+        $this->offerType = 'Simple';
+        $this->runGeneratorTest();
+        $this->checkCdata();
+    }
+
+    private function makeDescription() {
+        return new Cdata(self::CDATA_TEST_STRING);
+    }
+
+}


### PR DESCRIPTION
Sometimes it's desired to use CDATA in the resulting XML file instead of regular XML escaping.

Cdata wrapper class allows to achieve this:

```php
$html_desc = '<p>Some HTML code</p>';
$offer = (new OfferSimple())
    ->setDescription(new Cdata($html_desc))
```

will result in
```xml
<description><![CDATA[<p>Some HTML code</p>]]></description>
```

instead of

```xml
<description>&lt;p&gt;Some HTML code&lt;/p&gt;</description>
```