### PR TITLE
Add custom elements support and test for it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": ">=5.6.1",
-        "ext-simplexml": "^7.2"
+        "ext-simplexml": "*"
     },
     "require-dev": {
         "ext-dom": "*",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "issues": "https://github.com/Bukashk0zzz/YmlGenerator/issues"
     },
     "require": {
-        "php": ">=5.6.1"
+        "php": ">=5.6.1",
+        "ext-simplexml": "^7.2"
     },
     "require-dev": {
         "ext-dom": "*",

--- a/src/Model/Offer/AbstractOffer.php
+++ b/src/Model/Offer/AbstractOffer.php
@@ -111,7 +111,9 @@ abstract class AbstractOffer implements OfferInterface
      */
     private $cpa;
 
-    /** @var string[] */
+    /**
+     * @var string[]
+     */
     private $barcodes;
 
     /**
@@ -128,6 +130,13 @@ abstract class AbstractOffer implements OfferInterface
      * @var bool
      */
     private $store;
+
+    /**
+     * Array of custom elements (element types are keys) of arrays of element values
+     * There may be multiple elements of the same type
+     * @var array[]
+     */
+    private $customElements;
 
     /**
      * @return array
@@ -636,6 +645,66 @@ abstract class AbstractOffer implements OfferInterface
     }
 
     /**
+     * Sets list of custom elements
+     *
+     * @param array $customElements Array (keys are element types) of arrays (element values)
+     *
+     * @return $this
+     */
+    public function setCustomElements(array $customElements = [])
+    {
+        $this->customElements = $customElements;
+
+        return $this;
+    }
+
+    /**
+     * Add a custom element with given type and value
+     * Multiple elements of the same type are supported
+     *
+     * @param string $elementType
+     * @param mixed  $value
+     *
+     * @return $this
+     */
+    public function addCustomElement($elementType, $value)
+    {
+        // Add value to the list of values of the given element type creating array when needed
+        $this->customElements[$elementType][] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Returns a list of custom elements
+     * Always returns an array even if no custom elements were added
+     *
+     * @return array
+     */
+    public function getCustomElements()
+    {
+        return $this->customElements ?: [];
+    }
+
+    /**
+     * Returns a list of values for the specified custom element type
+     * Always returns an array
+     *
+     * @param string $elementType
+     *
+     * @return array
+     */
+    public function getCustomElementByType($elementType)
+    {
+        // TODO: Use ?? operator when support for PHP 5.6 is no longer needed
+        if (isset($this->customElements[$elementType])) {
+            return $this->customElements[$elementType];
+        }
+
+        return [];
+    }
+
+    /**
      * @return array
      */
     abstract protected function getOptions();
@@ -645,7 +714,7 @@ abstract class AbstractOffer implements OfferInterface
      */
     private function getHeaderOptions()
     {
-        return [
+        $options = [
             'url' => $this->getUrl(),
             'price' => $this->getPrice(),
             'oldprice' => $this->getOldPrice(),
@@ -659,6 +728,13 @@ abstract class AbstractOffer implements OfferInterface
             'weight' => $this->getWeight(),
             'local_delivery_cost' => $this->getLocalDeliveryCost(),
         ];
+
+        // Merge custom elements with header options
+        if ($this->customElements) {
+            $options += $this->customElements;
+        }
+
+        return $options;
     }
 
     /**

--- a/src/Model/Offer/AbstractOffer.php
+++ b/src/Model/Offer/AbstractOffer.php
@@ -714,7 +714,7 @@ abstract class AbstractOffer implements OfferInterface
      */
     private function getHeaderOptions()
     {
-        $options = [
+        return [
             'url' => $this->getUrl(),
             'price' => $this->getPrice(),
             'oldprice' => $this->getOldPrice(),
@@ -727,14 +727,7 @@ abstract class AbstractOffer implements OfferInterface
             'delivery' => $this->isDelivery(),
             'weight' => $this->getWeight(),
             'local_delivery_cost' => $this->getLocalDeliveryCost(),
-        ];
-
-        // Merge custom elements with header options
-        if ($this->customElements) {
-            $options += $this->customElements;
-        }
-
-        return $options;
+        ] + $this->getCustomElements();
     }
 
     /**

--- a/src/Model/Offer/AbstractOffer.php
+++ b/src/Model/Offer/AbstractOffer.php
@@ -669,8 +669,10 @@ abstract class AbstractOffer implements OfferInterface
      */
     public function addCustomElement($elementType, $value)
     {
-        // Add value to the list of values of the given element type creating array when needed
-        $this->customElements[$elementType][] = $value;
+        if ($value !== null) {
+            // Add value to the list of values of the given element type creating array when needed
+            $this->customElements[$elementType][] = $value;
+        }
 
         return $this;
     }

--- a/tests/AbstractGeneratorTest.php
+++ b/tests/AbstractGeneratorTest.php
@@ -79,9 +79,9 @@ abstract class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
     abstract protected function createOffer();
 
     /**
-     * Test generation
+     * Produces an XML file and writes to $this->settings->getOutputFile()
      */
-    protected function runGeneratorTest()
+    protected function generateFile()
     {
         static::assertTrue((new Generator($this->settings))->generate(
             $this->shopInfo,
@@ -90,7 +90,14 @@ abstract class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
             $this->createOffers(),
             $this->deliveries
         ));
+    }
 
+    /**
+     * Test generation
+     */
+    protected function runGeneratorTest()
+    {
+        $this->generateFile();
         $this->validateFileWithDtd();
     }
 

--- a/tests/OfferCustomElementsGeneratorTest.php
+++ b/tests/OfferCustomElementsGeneratorTest.php
@@ -59,7 +59,7 @@ class OfferCustomElementsGeneratorTest extends AbstractGeneratorTest
      */
     protected function createOffer()
     {
-        return (new OfferSimple())
+        $offer = (new OfferSimple())
             ->setAvailable($this->faker->boolean)
             ->setUrl($this->faker->url)
             ->setPrice($this->faker->numberBetween(1, 9999))
@@ -90,9 +90,15 @@ class OfferCustomElementsGeneratorTest extends AbstractGeneratorTest
             ->addCustomElement('custom_element', true)
             ->addCustomElement('custom_element', false)
             ->addCustomElement('custom_element', null) // Should not be written
-            ->addCustomElement('custom_element', new Cdata(self::CDATA_TEST_STRING))
+            ->addCustomElement('custom_element', $cdata = new Cdata(self::CDATA_TEST_STRING))
             ->addCustomElement('stock_quantity', 100) // https://rozetka.com.ua/sellerinfo/pricelist/
         ;
+
+
+        $this->assertSame([100500, 'string value', true, false, $cdata], $offer->getCustomElementByType('custom_element'));
+        $this->assertSame([100], $offer->getCustomElementByType('stock_quantity'));
+
+        return $offer;
     }
 
     /**

--- a/tests/OfferCustomElementsGeneratorTest.php
+++ b/tests/OfferCustomElementsGeneratorTest.php
@@ -94,9 +94,9 @@ class OfferCustomElementsGeneratorTest extends AbstractGeneratorTest
             ->addCustomElement('stock_quantity', 100) // https://rozetka.com.ua/sellerinfo/pricelist/
         ;
 
-
         $this->assertSame([100500, 'string value', true, false, $cdata], $offer->getCustomElementByType('custom_element'));
         $this->assertSame([100], $offer->getCustomElementByType('stock_quantity'));
+        $this->assertSame([], $offer->getCustomElementByType('non_existent_element'));
 
         return $offer;
     }

--- a/tests/OfferCustomElementsGeneratorTest.php
+++ b/tests/OfferCustomElementsGeneratorTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of the Bukashk0zzzYmlGenerator
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Bukashk0zzz\YmlGenerator\Tests;
+
+use Bukashk0zzz\YmlGenerator\Model\Offer\OfferSimple;
+use Bukashk0zzz\YmlGenerator\Cdata;
+
+/**
+ * Generator test
+ */
+class OfferCustomElementsGeneratorTest extends AbstractGeneratorTest
+{
+    const CDATA_TEST_STRING = '<p>Simple HTML</p></description></offer><![CDATA[';
+    const OFFER_COUNT = 2;
+
+    /**
+     * Test generate
+     */
+    public function testGenerate()
+    {
+        // Don't call $this->validateFileWithDtd() here because custom elements are not included into the default DTD
+        $this->generateFile();
+        $this->checkCustomElements();
+    }
+
+    /**
+     * Need to override parent::createOffers() in order to avoid setting description
+     * after calling self::createOffer()
+     *
+     * {@inheritDoc}
+     * @see \Bukashk0zzz\YmlGenerator\Tests\AbstractGeneratorTest::createOffers()
+     */
+    protected function createOffers()
+    {
+        $offers = [];
+        foreach (\range(1, self::OFFER_COUNT) as $id) {
+            $offers[] =
+                $this->createOffer()
+                    ->setId($id)
+                    ->setCategoryId($id)
+                ;
+        }
+
+        return $offers;
+    }
+
+    /**
+     * Set the test description with CDATA here
+     *
+     * {@inheritDoc}
+     * @see \Bukashk0zzz\YmlGenerator\Tests\AbstractGeneratorTest::createOffer()
+     */
+    protected function createOffer()
+    {
+        return (new OfferSimple())
+            ->setAvailable($this->faker->boolean)
+            ->setUrl($this->faker->url)
+            ->setPrice($this->faker->numberBetween(1, 9999))
+            ->setOldPrice($this->faker->numberBetween(1, 9999))
+            ->setWeight($this->faker->numberBetween(1, 9999))
+            ->setCurrencyId('UAH')
+            ->setDelivery($this->faker->boolean)
+            ->setLocalDeliveryCost($this->faker->numberBetween(1, 9999))
+            ->setSalesNotes($this->faker->text(45))
+            ->setManufacturerWarranty($this->faker->boolean)
+            ->setCountryOfOrigin('Украина')
+            ->setDownloadable($this->faker->boolean)
+            ->setAdult($this->faker->boolean)
+            ->setMarketCategory($this->faker->word)
+            ->setCpa($this->faker->numberBetween(0, 1))
+            ->setBarcodes([$this->faker->ean13, $this->faker->ean13])
+
+            ->setName($this->faker->name)
+            ->setVendor($this->faker->company)
+            ->setDescription($this->faker->sentence)
+            ->setVendorCode(null)
+            ->setPickup(true)
+            ->setGroupId($this->faker->numberBetween())
+            ->addPicture('http://example.com/example.jpeg')
+            ->addBarcode($this->faker->ean13)
+
+            ->addCustomElement('stock_quantity', 100) // https://rozetka.com.ua/sellerinfo/pricelist/
+            ->addCustomElement('custom_element', 100500)
+            ->addCustomElement('custom_element', 'string value')
+            ->addCustomElement('custom_element', true)
+            ->addCustomElement('custom_element', false)
+            ->addCustomElement('custom_element', null) // Should not be written
+            ->addCustomElement('custom_element', new Cdata(self::CDATA_TEST_STRING))
+        ;
+    }
+
+    /**
+     * Load generated XML file and check custom elements
+     */
+    private function checkCustomElements()
+    {
+        // Much easier to test with SimpleXML tahn with DOM
+        $yml = \simplexml_load_file($this->settings->getOutputFile());
+
+        $offers = $yml->shop->offers->offer;
+        $this->assertNotEmpty($offers);
+        $this->assertEquals(self::OFFER_COUNT, count($offers));
+
+        foreach ($offers as $offer) {
+            $prop = 'stock_quantity';
+            $this->assertSame(100, (int) $offer->$prop); // Can't use $offer->stock_quantity because of CS rules
+
+            $prop = 'custom_element';
+            $multipleElements = $offer->$prop; // Can't use $offer->custom_element because of CS rules
+            $this->assertNotEmpty($multipleElements);
+
+            // Verity each added value
+            $this->assertSame(100500, (int) $multipleElements[0]);
+            $this->assertSame('string value', (string) $multipleElements[1]);
+            $this->assertSame('true', (string) $multipleElements[2]);
+            $this->assertSame('false', (string) $multipleElements[3]);
+
+            // ->addCustomElement('custom_element', null) must not produce an element
+
+            $this->assertSame(self::CDATA_TEST_STRING, (string) $multipleElements[4]);
+        }
+    }
+
+    /**
+     * Create instance of Cdata class with a predefined test string
+     *
+     * @return \Bukashk0zzz\YmlGenerator\Cdata
+     */
+    private function makeDescription()
+    {
+        return new Cdata(self::CDATA_TEST_STRING);
+    }
+}

--- a/tests/OfferCustomElementsGeneratorTest.php
+++ b/tests/OfferCustomElementsGeneratorTest.php
@@ -86,13 +86,12 @@ class OfferCustomElementsGeneratorTest extends AbstractGeneratorTest
             ->addPicture('http://example.com/example.jpeg')
             ->addBarcode($this->faker->ean13)
 
-            ->addCustomElement('stock_quantity', 100) // https://rozetka.com.ua/sellerinfo/pricelist/
-            ->addCustomElement('custom_element', 100500)
-            ->addCustomElement('custom_element', 'string value')
+            ->setCustomElements(['custom_element' => [100500, 'string value']])
             ->addCustomElement('custom_element', true)
             ->addCustomElement('custom_element', false)
             ->addCustomElement('custom_element', null) // Should not be written
             ->addCustomElement('custom_element', new Cdata(self::CDATA_TEST_STRING))
+            ->addCustomElement('stock_quantity', 100) // https://rozetka.com.ua/sellerinfo/pricelist/
         ;
     }
 


### PR DESCRIPTION
Some alternative marketplaces has additional element definitions that are not part of the standard Yandex DTD.

One example is ```<stock_quantity>``` element described [here](https://rozetka.com.ua/sellerinfo/pricelist/).

This pull request adds support for custom offer elements by AbstractOffer class and a test for it. Multiple custom elements of the same type are supported.

Use:
```php
    $offer = (new OfferSimple())
        ->setId(100500)
        ->setAvailable(true)
        // ...
        ->addCustomElement('stock_quantity', 100);
```

will result in ```<stock_quantity>``` element added to the header section of the generated <offer> element:

```xml
<offer id="100500" available="true">
  <!-- ... -->
  <stock_quantity>100</stock_quantity>
  <!-- ... -->
</offer>

```

AbstractOffer class received 4 new methods:
- setCustomElements(array $customElements = [])
- addCustomElement($elementType, $value)
- getCustomElements()
- getCustomElementByType($elementType)

AbstractGeneratorTest was modified in order to extract generation code
from runGeneratorTest() method into generateFile() method

OfferCustomElementsGeneratorTest uses SimpleXML to load and check
generated values, added SimpleXMl as an extension requirement to
composer.json