### PR TITLE
PHPCS/Composer: update PHPCompatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - composer install --dev --prefer-dist --no-interaction
 
 script:
-  - ./vendor/bin/phpcs --standard=ruleset.xml
+  - ./vendor/bin/phpcs
   - ./vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover=coverage.xml
 
 after_success:

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "fzaninotto/faker": "^1.6",
         "friendsofphp/php-cs-fixer": "^2.3",
         "escapestudios/symfony2-coding-standard": "^3.0",
-        "wimg/php-compatibility": "^8.0"
+        "phpcompatibility/php-compatibility": "^9.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,12 +4,12 @@
 
     <exclude-pattern>vendor/</exclude-pattern>
 
-    <rule ref="vendor/wimg/php-compatibility/PHPCompatibility" />
-    <rule ref="./vendor/escapestudios/symfony2-coding-standard/Symfony">
+    <rule ref="PHPCompatibility" />
+    <rule ref="Symfony">
         <exclude name="Symfony.ControlStructure.YodaConditions.Invalid"/>
     </rule>
 
-    <config name="testVersion" value="5.5-7.1"/>
+    <config name="testVersion" value="5.6-"/>
 
     <arg name="colors"/>
     <arg name="encoding" value="utf-8"/>


### PR DESCRIPTION
Composer:
* `wimg/php-compatibility` has been abandoned for nearly a year. Use `phpcompatibility/php-compatibility` instead.
* Use the latest version of PHPCompatibility.
    You were missing out on a lot of new checks, including the checks to make sure your code is compatible with the upcoming PHP 7.4.
* Add the DealerDirect Composer PHPCS plugin.
    This plugin will handle setting the PHPCS `installed_paths` automatically.
    This also allows for referencing the ruleset by name instead of via the path in the ruleset, which is generally more stable.

PHPCS ruleset:
* Rename the ruleset to `phpcs.xml.dist` which will allow PHPCS to automatically pick up on it.
    No need to pass the `--standard=...` command-line argument anymore.
    Includes removing the argument from the Travis script.
* Check for cross-version compatibility for the PHP versions officially supported.
    According to the `composer.json` file, this code should be compatible with PHP 5.6 and above.
    PHPCompatibility _was_ checking against PHP 5.5 up to PHP 7.1.
    The new `testVersion` actually checks against PHP 5.6 up to the latest version (upcoming 7.4 at this moment).

Refs:
* https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions
* https://github.com/PHPCompatibility/PHPCompatibility/releases/
* https://github.com/Dealerdirect/phpcodesniffer-composer-installer