### PR TITLE
Use iterable to allow generators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -34,7 +34,7 @@ jobs:
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         run:  ./vendor/bin/phpcs
 
       - name: Run CS Fixer
-        run:  ./vendor/bin/php-cs-fixer fix --config=./.php_cs -v --dry-run
+        run:  PHP_CS_FIXER_IGNORE_ENV=true ./vendor/bin/php-cs-fixer fix --config=./.php_cs -v --dry-run
 
       - name: Run tests
         run: ./vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover=coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,12 @@ on:
 jobs:
   tests:
     name: PHPUnit PHP ${{ matrix.php }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         php:
-          - '5.6'
           - '7.1'
+          - '8.4'
       fail-fast: false
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,12 @@
     },
     "require-dev": {
         "ext-dom": "*",
-        "phpunit/phpunit": "^5.0",
-        "fzaninotto/faker": "^1.6",
+        "phpunit/phpunit": ">=7.0,<10",
         "friendsofphp/php-cs-fixer": "^2.3",
         "escapestudios/symfony2-coding-standard": "^3.0",
         "phpcompatibility/php-compatibility": "^9.0",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1"
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
+        "fakerphp/faker": "v1.20.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "issues": "https://github.com/Bukashk0zzz/YmlGenerator/issues"
     },
     "require": {
-        "php": ">=5.6.1",
+        "php": ">=7.1",
         "ext-simplexml": "*",
         "ext-xmlwriter": "*"
     },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,7 +9,7 @@
         <exclude name="Symfony.ControlStructure.YodaConditions.Invalid"/>
     </rule>
 
-    <config name="testVersion" value="5.6-"/>
+    <config name="testVersion" value="7.1-"/>
 
     <arg name="colors"/>
     <arg name="encoding" value="utf-8"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="vendor/autoload.php"
 >
 
@@ -18,13 +17,13 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./</directory>
-            <exclude>
-                <directory>./tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+        <exclude>
+            <directory>./tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </coverage>
 </phpunit>

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -70,14 +70,14 @@ class Generator
 
     /**
      * @param ShopInfo $shopInfo
-     * @param array    $currencies
-     * @param array    $categories
-     * @param array    $offers
-     * @param array    $deliveries
+     * @param iterable $currencies
+     * @param iterable $categories
+     * @param iterable $offers
+     * @param iterable $deliveries
      *
      * @return bool
      */
-    public function generate(ShopInfo $shopInfo, array $currencies, array $categories, array $offers, array $deliveries = [])
+    public function generate(ShopInfo $shopInfo, iterable $currencies, iterable $categories, iterable $offers, iterable $deliveries = [])
     {
         try {
             $this->addHeader();
@@ -229,9 +229,9 @@ class Generator
     /**
      * Adds <currencies> element. (See https://yandex.ru/support/webmaster/goods-prices/technical-requirements.xml#currencies)
      *
-     * @param array $currencies
+     * @param iterable $currencies
      */
-    private function addCurrencies(array $currencies)
+    private function addCurrencies(iterable $currencies)
     {
         $this->writer->startElement('currencies');
 
@@ -248,9 +248,9 @@ class Generator
     /**
      * Adds <categories> element. (See https://yandex.ru/support/webmaster/goods-prices/technical-requirements.xml#categories)
      *
-     * @param array $categories
+     * @param iterable $categories
      */
-    private function addCategories(array $categories)
+    private function addCategories(iterable $categories)
     {
         $this->writer->startElement('categories');
 
@@ -267,9 +267,9 @@ class Generator
     /**
      * Adds <delivery-option> element. (See https://yandex.ru/support/partnermarket/elements/delivery-options.xml)
      *
-     * @param array $deliveries
+     * @param iterable $deliveries
      */
-    private function addDeliveries(array $deliveries)
+    private function addDeliveries(iterable $deliveries)
     {
         $this->writer->startElement('delivery-options');
 
@@ -286,9 +286,9 @@ class Generator
     /**
      * Adds <offers> element. (See https://yandex.ru/support/webmaster/goods-prices/technical-requirements.xml#offers)
      *
-     * @param array $offers
+     * @param iterable $offers
      */
-    private function addOffers(array $offers)
+    private function addOffers(iterable $offers)
     {
         $this->writer->startElement('offers');
 

--- a/tests/AbstractGeneratorTest.php
+++ b/tests/AbstractGeneratorTest.php
@@ -18,11 +18,12 @@ use Bukashk0zzz\YmlGenerator\Model\Delivery;
 use Bukashk0zzz\YmlGenerator\Model\ShopInfo;
 use Bukashk0zzz\YmlGenerator\Settings;
 use Faker\Factory as Faker;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Abstract Generator test
  */
-abstract class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractGeneratorTest extends TestCase
 {
     /**
      * @var \Faker\Generator
@@ -62,7 +63,7 @@ abstract class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
     /**
      * Test setup
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->faker = Faker::create();
 

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -14,27 +14,36 @@ namespace Bukashk0zzz\YmlGenerator\Tests;
 use Bukashk0zzz\YmlGenerator\Generator;
 use Bukashk0zzz\YmlGenerator\Model\ShopInfo;
 use Bukashk0zzz\YmlGenerator\Settings;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Generator test
  */
-class GeneratorTest extends \PHPUnit_Framework_TestCase
+class GeneratorTest extends TestCase
 {
     /**
-     * @expectedException \RuntimeException
+     * Test exception if no output file used
      */
     public function testExceptionForIncompatibleAnnotations()
     {
+        // PHP 8.0+ throws ValueError
+        if (\PHP_VERSION > 8.0) {
+            $this->expectException(\ValueError::class);
+        } else {
+            $this->expectException(\RuntimeException::class);
+        }
+
         (new Generator((new Settings())->setOutputFile('')))
             ->generate(new ShopInfo(), [], [], [])
         ;
     }
 
     /**
-     * @expectedException \LogicException
+     * Test exception if no output file used
      */
     public function testExceptionIfManyDestinationUsed()
     {
+        $this->expectException(\LogicException::class);
         $settings = (new Settings())
             ->setOutputFile('')
             ->setReturnResultYMLString(true)


### PR DESCRIPTION
Change array to iterable to be able to use \Generator.
Bump min php version to 7.1 that supports iterable type


close https://github.com/Bukashk0zzz/YmlGenerator/issues/33#issue-626619846